### PR TITLE
Use random seed by default unless user specifies one

### DIFF
--- a/src/Rcpp-adapters/RcppModules.cpp
+++ b/src/Rcpp-adapters/RcppModules.cpp
@@ -41,7 +41,8 @@ RCPP_MODULE(ExaGeoStatCPP) {
 
     function("simulate_data", &exageostat::adapters::R_ExaGeoStatLoadData,
              List::create(_["kernel"], _["initial_theta"], _["distance_matrix"] = "euclidean", _["problem_size"],
-                          _["seed"] = 0, _["dts"], _["lts"] = 0, _["dimension"] = "2D", _["log_path"] = "",
+                          _["seed"] = static_cast<unsigned int>(time(0)), _["dts"], _["lts"] = 0,
+			  _["dimension"] = "2D", _["log_path"] = "",
                           _["data_path"] = "", _["observations_file"] = "", _["recovery_file"] = ""));
 
     function("model_data", &exageostat::adapters::R_ExaGeoStatModelData,

--- a/src/api/ExaGeoStat.cpp
+++ b/src/api/ExaGeoStat.cpp
@@ -27,7 +27,7 @@ using namespace exageostat::configurations;
 template<typename T>
 void ExaGeoStat<T>::ExaGeoStatLoadData(Configurations &aConfigurations, std::unique_ptr<ExaGeoStatData<T>> &aData) {
 
-    int seed = 0;
+    int seed = aConfigurations.GetSeed();
     std::srand(seed);
     aConfigurations.PrintSummary();
     LOGGER("** ExaGeoStat data generation/loading **")

--- a/src/configurations/Configurations.cpp
+++ b/src/configurations/Configurations.cpp
@@ -52,7 +52,7 @@ Configurations::Configurations() {
     SetLowerBounds(theta);
     SetUpperBounds(theta);
     SetEstimatedTheta(theta);
-    SetSeed(0);
+    SetSeed(static_cast<unsigned int>(time(0)));
     SetLogger(false);
     SetUnknownObservationsNb(0);
     SetApproximationMode(1);


### PR DESCRIPTION
This update sets a random seed by default (based on the current time) unless the user explicitly provides a specific seed value:
- Applied to both C++ and R versions
- Ensures consistent behavior across interfaces when no seed is provided
