### PR TITLE
Fix swapped location indices in UnivariateMaternNuggetsStationary covariance

### DIFF
--- a/src/kernels/concrete/UnivariateMaternNuggetsStationary.cpp
+++ b/src/kernels/concrete/UnivariateMaternNuggetsStationary.cpp
@@ -59,7 +59,7 @@ void UnivariateMaternNuggetsStationary<T>::GenerateCovarianceMatrix(T *apMatrixA
         for (i = 0; i < aRowsNumber; i++) {
             j0 = aColumnOffset;
             for (j = 0; j < aColumnsNumber; j++) {
-                expr = DistanceCalculationHelpers<T>::CalculateDistance(aLocation1, aLocation2, j0, i0, aDistanceMetric,
+                expr = DistanceCalculationHelpers<T>::CalculateDistance(aLocation1, aLocation2, i0, j0, aDistanceMetric,
                                                                         flag) / aLocalTheta[1];
                 if (expr == 0) {
                     apMatrixA[i + j * aRowsNumber] = sigma_square + aLocalTheta[3];
@@ -77,7 +77,7 @@ void UnivariateMaternNuggetsStationary<T>::GenerateCovarianceMatrix(T *apMatrixA
             j0 = aColumnOffset;
             for (j = 0; j < aColumnsNumber; j++) {
                 flag = 1;
-                expr = DistanceCalculationHelpers<T>::CalculateDistance(aLocation1, aLocation2, j0, i0, aDistanceMetric,
+                expr = DistanceCalculationHelpers<T>::CalculateDistance(aLocation1, aLocation2, i0, j0, aDistanceMetric,
                                                                         flag);
                 if (expr == 0) {
                     apMatrixA[i + j * aRowsNumber] = sigma_square + aLocalTheta[3];

--- a/tests/cpp-tests/kernels/concrete/TestUnivariateMaternNuggetsCrossCovariance.cpp
+++ b/tests/cpp-tests/kernels/concrete/TestUnivariateMaternNuggetsCrossCovariance.cpp
@@ -1,0 +1,108 @@
+
+// Copyright (c) 2017-2024 King Abdullah University of Science and Technology,
+// All rights reserved.
+// ExaGeoStat is a software package, provided by King Abdullah University of Science and Technology (KAUST).
+
+/**
+ * @file TestUnivariateMaternNuggetsCrossCovariance.cpp
+ * @brief Regression test for the location-index order of the UnivariateMaternNuggetsStationary kernel.
+ * @details The existing kernel test exercises only the symmetric (train-train) covariance matrix, where
+ * the matrix entry (i, j) is computed from the distance between two points drawn from the SAME location
+ * set. Because the Euclidean distance is symmetric, an accidental swap of the two location indices is
+ * invisible there: d(loc[i], loc[j]) == d(loc[j], loc[i]).
+ *
+ * This test instead builds a rectangular CROSS-covariance matrix between two DIFFERENT location sets,
+ * exactly as the prediction path does when assembling C12 between observed and missing points. For two
+ * distinct location sets, entry (i, j) must use d(location1[i], location2[j]); swapping the indices to
+ * d(location1[j], location2[i]) produces a different (effectively transposed) matrix and therefore wrong
+ * predictions.
+ *
+ * The expected values are computed independently of the kernel, using the closed-form Matern covariance
+ * for nu = 0.5, which reduces to the exponential covariance sigma^2 * exp(-d / beta). This makes the
+ * reference values self-evident and independent of any internal index convention.
+ * @version 1.1.0
+**/
+
+#include <cmath>
+#include <vector>
+
+#include <catch2/catch_all.hpp>
+
+#include <kernels/Kernel.hpp>
+#include <data-units/Locations.hpp>
+
+using namespace std;
+
+using namespace exageostat::common;
+using namespace exageostat::dataunits;
+using namespace exageostat::kernels;
+using namespace exageostat::plugins;
+
+void TEST_NUGGETS_CROSS_COVARIANCE() {
+
+    SECTION("UnivariateMaternNuggetsStationary cross-covariance respects location-index order") {
+
+        // Matern parameters: sigma^2 = 1, beta (range) = 1, nu = 0.5, nugget = 0.5.
+        // With nu = 0.5 the Matern covariance reduces to the exponential covariance:
+        //     C(d) = sigma^2 * exp(-d / beta)        for d > 0
+        //     C(0) = sigma^2 + nugget                for d = 0
+        double theta[4] = {1.0, 1.0, 0.5, 0.5};
+        const double sigma_square = theta[0];
+        const double beta = theta[1];
+        const double nugget = theta[3];
+
+        const int rows = 3;    // number of "row" points, indexed from location set 1
+        const int cols = 3;    // number of "column" points, indexed from location set 2
+
+        // Two DISTINCT location sets so the cross-covariance is asymmetric.
+        // Row points lie on the y-axis, column points lie on the x-axis.
+        vector<double> row_x = {0.0, 0.0, 0.0};
+        vector<double> row_y = {0.0, 1.0, 2.0};
+        vector<double> col_x = {0.0, 3.0, 6.0};
+        vector<double> col_y = {0.0, 0.0, 0.0};
+
+        Locations<double> location1(rows, Dimension2D);
+        location1.SetLocationX(*row_x.data(), rows);
+        location1.SetLocationY(*row_y.data(), rows);
+
+        Locations<double> location2(cols, Dimension2D);
+        location2.SetLocationX(*col_x.data(), cols);
+        location2.SetLocationY(*col_y.data(), cols);
+
+        auto *kernel = PluginRegistry<Kernel<double>>::Create("UnivariateMaternNuggetsStationary", 1);
+        REQUIRE(kernel != nullptr);
+
+        // Output matrix in column-major layout: A[i + j * rows].
+        vector<double> matrix(rows * cols, 0.0);
+
+        // Distance metric 0 -> Euclidean (metric 1 is reserved for great-circle/Haversine).
+        const int distance_metric = 0;
+        kernel->GenerateCovarianceMatrix(matrix.data(), rows, cols, /*row offset*/ 0, /*column offset*/ 0,
+                                         location1, location2, location1, theta, distance_metric);
+
+        // Build the reference cross-covariance independently of the kernel.
+        for (int i = 0; i < rows; i++) {
+            for (int j = 0; j < cols; j++) {
+                const double dx = row_x[i] - col_x[j];
+                const double dy = row_y[i] - col_y[j];
+                const double distance = sqrt(dx * dx + dy * dy);
+                const double expected = (distance == 0.0) ? (sigma_square + nugget)
+                                                          : sigma_square * exp(-distance / beta);
+                const double actual = matrix[i + j * rows];
+                INFO("entry (" << i << ", " << j << "): distance = " << distance);
+                REQUIRE(actual == Catch::Approx(expected).margin(1e-9));
+            }
+        }
+
+        // The single most diagnostic entry (0, 1): row point (0,0), column point (3,0).
+        //   Correct : d(location1[0]=(0,0), location2[1]=(3,0)) = 3 -> exp(-3) ~= 0.0498
+        //   Swapped : d(location1[1]=(0,1), location2[0]=(0,0)) = 1 -> exp(-1) ~= 0.3679  (the bug)
+        REQUIRE(matrix[0 + 1 * rows] == Catch::Approx(exp(-3.0)).margin(1e-9));
+
+        delete kernel;
+    }
+}
+
+TEST_CASE("UnivariateMaternNuggetsStationary cross-covariance index-order regression") {
+    TEST_NUGGETS_CROSS_COVARIANCE();
+}


### PR DESCRIPTION
### Summary

`UnivariateMaternNuggetsStationary::GenerateCovarianceMatrix` passes the two
location indices to `CalculateDistance` in the wrong order, `(j0, i0)` instead
of `(i0, j0)`. Every other kernel in the project passes `(i0, j0)`.

### Root cause

The distance helper signature is:

```cpp
CalculateDistance(Locations &loc1, Locations &loc2, idxInto_loc1, idxInto_loc2, ...)
```

In the generation loop, `i0` walks the rows (indexing `aLocation1`) and `j0`
walks the columns (indexing `aLocation2`), so the correct call is
`(..., i0, j0, ...)`. The nuggets kernel instead calls `(..., j0, i0, ...)` in
both branches.

This is invisible for the **symmetric** train-train covariance matrix, because
the Euclidean distance is symmetric: `d(loc[i], loc[j]) == d(loc[j], loc[i])`.
That is why synthetic data generation and MLE are unaffected, and why the
existing kernel test (which only checks the symmetric matrix) never caught it.

It does corrupt the **rectangular cross-covariance** matrix `C12` assembled
during prediction, where the two location sets (observed and missing) differ.
Entry `(i, j)` ends up using `d(location1[j], location2[i])` instead of
`d(location1[i], location2[j])`, the transposed matrix, producing wrong
kriging predictions whenever this kernel is used for prediction.

### Fix

```diff
-                expr = DistanceCalculationHelpers<T>::CalculateDistance(aLocation1, aLocation2, j0, i0, aDistanceMetric,
+                expr = DistanceCalculationHelpers<T>::CalculateDistance(aLocation1, aLocation2, i0, j0, aDistanceMetric,
```

(applied to both branches of `GenerateCovarianceMatrix`).

### Test

Adds `TestUnivariateMaternNuggetsCrossCovariance.cpp`: it builds a 3×3
cross-covariance between two **distinct** location sets and checks every entry
against an independently computed reference. With `nu = 0.5` the Matérn
covariance reduces to the exponential covariance `sigma^2 * exp(-d / beta)`, so
the reference values are self-evident and do not depend on any internal index
convention.

- With the swapped indices, entry `(0,1)` resolves to `exp(-1) ≈ 0.36788` (the
  transposed pair, distance 1) instead of `exp(-3) ≈ 0.04979` (distance 3), so
  the test distinguishes the two index orders.
- With the corrected indices, every entry matches the reference.
- The existing symmetric kernel test is unaffected, since the symmetric
  (data-generation / MLE) path does not depend on the index order.

### Note

Companion fix: the R-interface prediction problem-size fix (#59). The
two are independent code changes (disjoint files); both are needed together for
fully correct end-to-end kriging predictions with the nuggets kernel.
